### PR TITLE
solver/lid: Check if suction head is negative in validateLidProc

### DIFF
--- a/src/solver/lid.c
+++ b/src/solver/lid.c
@@ -998,6 +998,7 @@ void validateLidProc(int j)
         if ( LidProcs[j].soil.porosity      <= 0.0 
         ||   LidProcs[j].soil.fieldCap      >= LidProcs[j].soil.porosity
         ||   LidProcs[j].soil.wiltPoint     >= LidProcs[j].soil.fieldCap
+        ||   LidProcs[j].soil.suction       <  0.0
         ||   LidProcs[j].soil.kSat          <= 0.0
         ||   LidProcs[j].soil.kSlope        <  0.0 )
         {


### PR DESCRIPTION
When validating LID process parameters, the suction head should be also validated. According to "Storm Water Management Model User's Manual Version 5.1", "suction head" should be >=0, so add a check in `validateLidProc` to make sure "suction" is also valid.