### PR TITLE
revise version management

### DIFF
--- a/extern/version.h.in
+++ b/extern/version.h.in
@@ -29,6 +29,7 @@
 #define COMPILER_VERSION    "@CMAKE_C_COMPILER_VERSION@"
 #define BUILD_ID            "@BUILD_ID@"
 
+#define TOOLKIT_VERSION          "1.0"
 
 static inline int get_version_legacy() { \
     return VERSION_MAJOR * 10000 + VERSION_MINOR * 1000 + VERSION_PATCH; \

--- a/src/solver/report.c
+++ b/src/solver/report.c
@@ -227,9 +227,10 @@ void report_writeLogo()
 //
 // OWA manages model version differently from EPA SWMM. 
 {
+    fprintf(Frpt.file, FMT08);
 	sprintf(Msg, \
-		"\n  OWA STORM WATER MANAGEMENT MODEL - VERSION v%s (OWA %.10s)", 
-        VERSION, BUILD_ID);
+		"\n  PYSWMM TOOLKIT API - VERSION v%s (%.10s)", 
+        TOOLKIT_VERSION, BUILD_ID);
 
     fprintf(Frpt.file, "%s", Msg);
     fprintf(Frpt.file, FMT09);


### PR DESCRIPTION
This PR is to create a discussion around an approach to address #382

The changes in this PR at the time of its submission restore the EPA version management approach (constant int defined in [consts.h](https://github.com/pyswmm/Stormwater-Management-Model/blob/414a397d40f726672f2458d180f8f8e747b8ae74/src/solver/consts.h#L19)). The EPA versioning is maintained to define the EPA engine upon which the pyswmm-SWMM code is based. When changes are made in EPA code, they (along with the version definition) will be merged into this fork without updating the version defined in the swmm-solver cmake project.

The swmm-solver version that is defined in the [CMakeLists.txt file](https://github.com/pyswmm/Stormwater-Management-Model/blob/414a397d40f726672f2458d180f8f8e747b8ae74/CMakeLists.txt#L25) is repurposed to define the version of the toolkit API. As changes are made to the toolkit api, the swmm-solver version should be incremented accordingly.

The [EPA report file header is restored](https://github.com/pyswmm/Stormwater-Management-Model/blob/develop_version_management/src/solver/report.c#L230) to document the EPA engine version that was used to run the simulation. [A second header line is added to the report file](https://github.com/pyswmm/Stormwater-Management-Model/blob/414a397d40f726672f2458d180f8f8e747b8ae74/src/solver/report.c#L231-L235) to document the pyswmm toolkit version included in the engine used to run the simulation. Restoring the EPA header to the first line of the rpt file has the added benefit of making it compatible with  PCSWMM gui software, where as previously the OWA header would prevent the PCSWMM from parsing the rpt file properly. 

In addition to these changes, I'd like to discuss revising code annotations in the source code. Previously the SWMM model was defined as OWA SWMM. Since the project has migrated away from OWA, I am wondering if we should rebrand the source code accordingly. I propose instances of "OWA" or "Open Water Analytics" in the source code by replaced with "pyswmm". Thoughts?

Since the rpt file header has changed, regression tests will fail until this new engine is used to generate new benchmark files with the updated rpt header.

@bemcdonnell @abhiramm7 @michaeltryby