### PR TITLE
Modified API for initial conditions

### DIFF
--- a/src/solver/toolkit.c
+++ b/src/solver/toolkit.c
@@ -673,8 +673,8 @@ EXPORT_TOOLKIT int swmm_setNodeParam(int index, SM_NodeProperty param, double va
     {
         error_code = ERR_TKAPI_INPUTNOTOPEN;
     }
-     // Check if Simulation is Running
-    else if(swmm_IsStartedFlag() == TRUE)
+    // Check if Simulation is Running (except if "overriding" initial Depth)
+    else if(swmm_IsStartedFlag() == TRUE && param != SM_INITDEPTH)
     {
         error_code = ERR_TKAPI_SIM_NRUNNING;
     }

--- a/tests/solver/test_toolkit.cpp
+++ b/tests/solver/test_toolkit.cpp
@@ -120,7 +120,9 @@ BOOST_FIXTURE_TEST_CASE(sim_started_check, FixtureBeforeStep) {
     //Node
     error = swmm_setNodeParam(0, SM_INVERTEL, 1);
     BOOST_CHECK_EQUAL(error, ERR_TKAPI_SIM_NRUNNING);
-
+    //Added an exception
+    error = swmm_setNodeParam(0, SM_INITDEPTH, 1);
+    BOOST_CHECK_EQUAL(error, ERR_NONE);
 
     //Link
     error = swmm_setLinkParam(0, SM_OFFSET1, 1);


### PR DESCRIPTION
First part in addressing [pyswmm-445](https://github.com/pyswmm/pyswmm/issues/445)

@karosc, i learned a new command to type before making a commit to swmm... if you have a million white space changes, this command saves you `git diff -w | git apply --cached --ignore-whitespace` 

This will solve the initial conditions problem for network levels.  The "settings" are solved just by organizing the sim.start()