### PR TITLE
Arm64 Regression testing

### DIFF
--- a/.github/docker_tools/run_regression_tests.sh
+++ b/.github/docker_tools/run_regression_tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#script for running regression tests in arm64 docker container
+
+# setup environment
+git config --global --add safe.directory /swmm
+cd swmm
+python3 -m venv venv
+source venv/bin/activate
+pip install aenum nrtest swmm-toolkit nrtest-swmm
+
+# export build vars
+export BUILD_HOME="build"
+export PROJECT="swmm"
+export PLATFORM="linux"
+
+# run regression tests
+./ci-tools/linux/make.sh
+source ./ci-tools/linux/before-nrtest.sh
+bash ./ci-tools/linux/run-nrtests.sh

--- a/.github/workflows/build-test-arm64.yaml
+++ b/.github/workflows/build-test-arm64.yaml
@@ -1,0 +1,44 @@
+name: Build and Test ARM64
+
+on: workflow_dispatch
+
+jobs:
+  cross-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Clone ci-tools repo
+        uses: actions/checkout@v3
+        with:
+          repository: pyswmm/ci-tools
+          ref: master
+          path: ci-tools
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+      
+      - name: start docker
+        run: docker run -id --name cross --volume="./:/swmm" --cpuset-cpus="0" karosc/build_swmm_arm64v8:latest
+
+      - name: Build and unit test
+        run: docker exec cross /bin/bash -c "cd /swmm && ./ci-tools/linux/make.sh -t -g 'Unix Makefiles'"
+
+      - name: Build for reg test
+        run: >
+          chmod +x ./.github/docker_tools/run_reg_test.sh &&
+          docker exec cross /bin/bash -c "/swmm/.github/docker_tools/run_reg_test.sh"
+
+      - name: Upload artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-test-artifacts
+          path: upload/*.*

--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -99,13 +99,18 @@ file(COPY ${CMAKE_CURRENT_BINARY_DIR}/toolkit_export.h
     DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
+if(APPLE)
+    set(LIB_ROOT "@loader_path")
+else()
+    set(LIB_ROOT "$ORIGIN")
+endif()
 
 set_target_properties(swmm5
     PROPERTIES
         MACOSX_RPATH TRUE
         SKIP_BUILD_RPATH FALSE
         BUILD_WITH_INSTALL_RPATH FALSE
-        INSTALL_RPATH "${PACKAGE_RPATH}"
+        INSTALL_RPATH "${LIB_ROOT};${PACKAGE_RPATH};"
         INSTALL_RPATH_USE_LINK_PATH TRUE
 )
 


### PR DESCRIPTION
This PR sets up emulated arm64 regression testing. Since the tests are emulated, they take a super long time to run (~3hrs). I've set them up to be manually triggered only, but they are import to have on our journey to getting official support for arm64 and apple silicon.