### PR TITLE
remove boost shared library link from header only test suite

### DIFF
--- a/tests/outfile/CMakeLists.txt
+++ b/tests/outfile/CMakeLists.txt
@@ -16,8 +16,7 @@ target_include_directories(test_output
 )
 
 target_link_libraries(test_output
-    ${Boost_LIBRARIES}
-    swmm-output
+     swmm-output
 )
 
 set_target_properties(test_output

--- a/tests/solver/CMakeLists.txt
+++ b/tests/solver/CMakeLists.txt
@@ -20,7 +20,6 @@ add_executable(test_lid
 )
 
 target_link_libraries(test_lid
-    ${Boost_LIBRARIES}
     swmm5
 )
 
@@ -52,7 +51,6 @@ target_compile_features(test_solver
 )
 
 target_link_libraries(test_solver
-    ${Boost_LIBRARIES}
     swmm5
 )
 


### PR DESCRIPTION
I started running Fedora 40 on my personal laptop and found that SWMM wouldn't pass unit tests on that OS. Fedora is known for running newer software than debian/ubuntu and I wanted to understand why the tests would not pass. I was getting all sorts of malloc errors suggesting there was a memory leak in boost, but I doubted that could be true.

Turns out our Boost.Test configuration is not quite correct and breaks in newer versions of our linux build stack (gcc/cmake/boost). Our Solver, LID, and output test suites are configured as [header-only suites](https://github.com/pyswmm/Stormwater-Management-Model/blob/main/tests/solver/test_lid.cpp#L18), but cmake is [configured to link boost](https://github.com/pyswmm/Stormwater-Management-Model/blob/main/tests/solver/CMakeLists.txt#L23) as if our tests are configured as [the shared variant](https://www.boost.org/doc/libs/1_83_0/libs/test/doc/html/boost_test/usage_variants.html#boost_test.usage_variants.shared_lib).

After consulting the [cmake docs](https://cmake.org/cmake/help/v3.8/module/FindBoost.html) and [boost docs](https://www.boost.org/doc/libs/1_83_0/libs/test/doc/html/boost_test/usage_variants.html#boost_test.usage_variants.shared_lib), I thought it best to remove the boost link....which solved my issues on fedora 40.

Regression tests still are failing on mac and windows, but that's a separate issue entirely.